### PR TITLE
Implement one-class dynamic analysis option

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,11 @@ The malware detection pipeline follows these steps:
 
 1. **Data Loading**: Load static and dynamic features from CICAndMAl2020 dataset
 2. **Feature Selection**: Select optimal features using importance-based methods
-3. **Model Training**: Train Random Forest (static) and XGBoost (dynamic) models
+3. **Model Training**: Train Random Forest (static) and either XGBoost or one-class models (Isolation Forest, One-Class SVM) for dynamic analysis
 4. **Sequential Detection**:
    - Stage 1: Process all samples with static analysis (low computational cost)
    - Stage 2: Only suspicious samples undergo dynamic analysis (higher computational cost)
-   - Final decision combines results from both stages
+   - Final decision combines results from both stages with appropriate weighting
 5. **Evaluation**: Performance metrics and computational efficiency measurements
 
 ## Parameter Explanations
@@ -100,12 +100,26 @@ For testing and development, the following additional command-line arguments are
 - `--clear-results`: Clear previous results from the output directory before running
 - `--n-jobs`: Number of processes for parallel processing (default: use all cores)
 - `--cache-dir`: Directory to cache preprocessed data (default: results/cache)
+- `--dynamic-model-type`: Type of model to use for dynamic analysis (choices: "xgboost", "isolation-forest", "one-class-svm")
 
 These options are particularly useful when:
 - Developing or debugging specific parts of the pipeline
 - Verifying dataset loading and preprocessing
 - Testing on limited hardware resources
 - Benchmarking individual components
+
+## Dataset Limitations and Adaptations
+
+The CICAndMAl2020 dataset has a critical limitation: the dynamic portion contains only malware samples (no benign samples). To address this:
+
+- **Default behavior**: When only one class is available in dynamic data, a `DummyClassifier` is used.
+- **Alternative approach**: Using the `--dynamic-model-type isolation-forest` argument implements a one-class classifier that learns patterns of typical malware behavior from available samples.
+- **When to use**: The Isolation Forest approach is recommended when working with the CICAndMAl2020 dataset as it provides meaningful anomaly detection relative to known malware patterns.
+
+Example:
+```bash
+uv run code/sequential_malware_analysis.py --sample-size 0.05 --dynamic-model-type isolation-forest
+```
 
 ## Extending with New Datasets
 

--- a/code/cicandmal2020_loader.py
+++ b/code/cicandmal2020_loader.py
@@ -204,12 +204,15 @@ def load_cicandmal2020_dynamic_dataset(directory_path, use_before_reboot=True, s
         return None
     
     logger.info(f"Found {len(dynamic_files)} dynamic CSV files for {timing_suffix}")
+    logger.info(f"File names: {[os.path.basename(f) for f in dynamic_files]}")
     
     for file_path in dynamic_files:
         try:
             # Extract category from filename
             filename = os.path.basename(file_path)
             category = filename.replace(f"_{timing_suffix}_Cat.csv", "")
+            
+            logger.info(f"Processing file: {filename}, extracted category: '{category}'")
             
             # Use efficient chunk processing for large files
             chunk_size = 10000  # Adjust based on memory constraints
@@ -220,18 +223,17 @@ def load_cicandmal2020_dynamic_dataset(directory_path, use_before_reboot=True, s
                 chunk['category'] = category
                 
                 # Add class label (0 for benign, 1 for any malware)
-                chunk['class'] = 0 if category.lower() == 'benign' else 1
+                is_benign = category.lower() == 'benign'
+                chunk['class'] = 0 if is_benign else 1
+                logger.info(f"Category '{category}' assigned class: {0 if is_benign else 1}")
                 
-                # Take a sample if needed
-                if sample_size < 1.0:
-                    chunk = chunk.sample(frac=sample_size, random_state=42)
-                
+                # Sampling will be done after combining all data
                 chunks.append(chunk)
             
             if chunks:
                 df = pd.concat(chunks, ignore_index=True)
                 all_data.append(df)
-                logger.info(f"Loaded {len(df)} dynamic samples from {category}")
+                logger.info(f"Loaded {len(df)} dynamic samples from {category} with class {0 if category.lower() == 'benign' else 1}")
             
         except Exception as e:
             logger.error(f"Error loading {os.path.basename(file_path)}: {e}")
@@ -240,6 +242,35 @@ def load_cicandmal2020_dynamic_dataset(directory_path, use_before_reboot=True, s
     if all_data:
         combined_df = pd.concat(all_data, ignore_index=True)
         logger.info(f"Total combined dynamic samples: {len(combined_df)}")
+        class_dist = combined_df['class'].value_counts().to_dict()
+        logger.info(f"Class distribution in combined dynamic data: {class_dist}")
+
+        # If sample_size < 1.0, take a stratified sample from the combined data
+        if sample_size < 1.0:
+            logger.info(f"Taking {sample_size*100:.1f}% stratified sample of combined dynamic data")
+            # Stratified sampling by malware class if class column exists and has multiple classes
+            if 'class' in combined_df.columns and combined_df['class'].nunique() > 1:
+                try:
+                    # Ensure group_keys=False for pandas >= 1.5 compatibility if needed, though default is often fine
+                    combined_df = combined_df.groupby('class', group_keys=False).apply(
+                        lambda x: x.sample(frac=sample_size, random_state=42) if len(x) > 0 else x
+                    )
+                    logger.info(f"Sampled down to {len(combined_df)} dynamic samples")
+                except ValueError as e:
+                    # Handle cases where a group might be too small for sampling the requested fraction
+                    logger.warning(f"Could not perform stratified sampling likely due to small group size: {e}. Applying simple random sampling instead.")
+                    combined_df = combined_df.sample(frac=sample_size, random_state=42)
+                    logger.info(f"Sampled down to {len(combined_df)} dynamic samples using simple random sampling.")
+            elif 'class' in combined_df.columns:
+                 # Handle case where class column exists but has only one class
+                 logger.warning("Class column has only one value. Applying simple random sampling.")
+                 combined_df = combined_df.sample(frac=sample_size, random_state=42)
+                 logger.info(f"Sampled down to {len(combined_df)} dynamic samples using simple random sampling.")
+            else:
+                # Fallback to simple random sampling if 'class' column is missing
+                logger.warning("Class column missing. Applying simple random sampling.")
+                combined_df = combined_df.sample(frac=sample_size, random_state=42)
+                logger.info(f"Sampled down to {len(combined_df)} dynamic samples using simple random sampling.")
         
         # Save cache if cache_dir is provided
         if cache_dir:

--- a/code/sequential_detector.py
+++ b/code/sequential_detector.py
@@ -17,6 +17,8 @@ from sklearn.metrics import (
 )
 import matplotlib.pyplot as plt
 import seaborn as sns
+from sklearn.ensemble import IsolationForest
+from sklearn.svm import OneClassSVM
 
 # Set up logging
 logger = logging.getLogger("malware_analysis.sequential")
@@ -153,9 +155,28 @@ class SequentialMalwareDetector:
                     try:
                         # Access by index label (not position)
                         dynamic_sample = X_dynamic_filtered.loc[[idx]]
-                        dynamic_probs = self.dynamic_model.predict_proba(dynamic_sample)
-                        # Extract probability for positive class if available
-                        dynamic_prob = dynamic_probs[0, 1] if dynamic_probs.shape[1] > 1 else dynamic_probs[0, 0]
+                        
+                        # Check model type for prediction method
+                        if hasattr(self.dynamic_model, 'predict_proba'):
+                            # Standard classifier (like XGBoost)
+                            dynamic_probs = self.dynamic_model.predict_proba(dynamic_sample)
+                            # Extract probability for positive class (malware)
+                            dynamic_prob = dynamic_probs[0, 1] if dynamic_probs.shape[1] > 1 else dynamic_probs[0, 0]
+                        elif isinstance(self.dynamic_model, (IsolationForest, OneClassSVM)):
+                            # One-Class models
+                            prediction = self.dynamic_model.predict(dynamic_sample)[0]
+                            # Map prediction (+1 inlier/malware, -1 outlier/anomaly) to a probability-like score
+                            # Assign high probability if inlier (malware), low if outlier (anomaly)
+                            dynamic_prob = 0.9 if prediction == 1 else 0.1
+                            # Alternative: Use decision_function/score_samples and scale? For now, keep it simple.
+                            # score = self.dynamic_model.decision_function(dynamic_sample)[0] # OCSVM
+                            # score = self.dynamic_model.score_samples(dynamic_sample)[0] # IF (lower is more abnormal)
+                            # dynamic_prob = 1 / (1 + np.exp(-score)) # Example scaling
+                        else:
+                             # Fallback or handle other model types if necessary
+                             logger.warning(f"Unsupported dynamic model type for probability extraction: {type(self.dynamic_model)}. Using static analysis only.")
+                             dynamic_prob = None
+
                     except Exception as e:
                         logger.warning(f"Dynamic prediction failed for index {idx}: {e}. Using static analysis only.")
                         dynamic_prob = None

--- a/code/sequential_malware_analysis.py
+++ b/code/sequential_malware_analysis.py
@@ -55,6 +55,9 @@ def parse_arguments():
                         help="Skip sequential pipeline evaluation")
     parser.add_argument("--clear-results", action="store_true",
                         help="Clear previous results before running")
+    parser.add_argument("--dynamic-model-type", type=str, default="xgboost",
+                        choices=["xgboost", "isolation-forest", "one-class-svm"],
+                        help="Type of model for dynamic analysis (default: xgboost)")
     
     return parser.parse_args()
 
@@ -309,7 +312,8 @@ def main():
                 # Import necessary libraries
                 import numpy as np
                 from sklearn.model_selection import train_test_split
-                from sklearn.ensemble import RandomForestClassifier
+                from sklearn.ensemble import RandomForestClassifier, IsolationForest
+                from sklearn.svm import OneClassSVM
                 from sklearn.dummy import DummyClassifier
                 import xgboost as xgb
                 
@@ -357,32 +361,67 @@ def main():
                 )
                 static_model.fit(X_static_train[static_selected_features], y_static_train)
                 
-                # Train a basic dynamic model
-                logger.info("Training dynamic model...")
+                # Train the dynamic model based on the selected type
+                logger.info(f"Training dynamic model (type: {args.dynamic_model_type})...")
                 
-                # Check if dynamic dataset has enough classes for classification
-                unique_classes = y_dynamic.unique()
-                if len(unique_classes) < 2:
-                    logger.warning(f"Dynamic dataset has only one class ({unique_classes[0]}). Using DummyClassifier instead.")
-                    from sklearn.dummy import DummyClassifier
-                    dynamic_model = DummyClassifier(strategy="constant", constant=unique_classes[0])
-                    dynamic_model.fit(X_dynamic, y_dynamic)
-                else:
-                    dynamic_model = xgb.XGBClassifier(
+                # Select dynamic features (needs same feature names later for prediction)
+                # Using all available dynamic features for one-class models might be better
+                dynamic_selected_features = list(X_dynamic.columns)
+                X_dynamic_selected = X_dynamic[dynamic_selected_features]
+
+                if args.dynamic_model_type == "xgboost":
+                    # Check if dynamic dataset has enough classes for XGBoost
+                    unique_classes = y_dynamic.unique()
+                    if len(unique_classes) < 2:
+                        logger.warning(f"Dynamic dataset has only one class ({unique_classes[0]}) for XGBoost. Using DummyClassifier instead.")
+                        dynamic_model = DummyClassifier(strategy="constant", constant=unique_classes[0])
+                        dynamic_model.fit(X_dynamic_selected, y_dynamic)
+                    else:
+                        logger.info("Using XGBoost for dynamic analysis.")
+                        dynamic_model = xgb.XGBClassifier(
+                            n_estimators=50 if args.quick_mode else 100,
+                            learning_rate=0.1,
+                            max_depth=5,
+                            random_state=42,
+                            n_jobs=args.n_jobs if args.parallel else 1,
+                            use_label_encoder=False, # Avoid potential deprecation warnings
+                            eval_metric='logloss'     # Avoid potential deprecation warnings
+                        )
+                        dynamic_model.fit(X_dynamic_selected, y_dynamic)
+
+                elif args.dynamic_model_type == "isolation-forest":
+                    logger.info("Using Isolation Forest (One-Class) for dynamic analysis.")
+                    # Contamination='auto' or a small float e.g., 0.01 might be suitable
+                    # We assume the input data X_dynamic contains only malware (inliers for this model)
+                    dynamic_model = IsolationForest(
                         n_estimators=50 if args.quick_mode else 100,
-                        learning_rate=0.1,
-                        max_depth=5,
+                        contamination='auto', # Let the model estimate contamination
                         random_state=42,
                         n_jobs=args.n_jobs if args.parallel else 1
                     )
-                    dynamic_model.fit(X_dynamic, y_dynamic)
+                    # Fit on the dynamic features (no labels needed)
+                    dynamic_model.fit(X_dynamic_selected)
+
+                elif args.dynamic_model_type == "one-class-svm":
+                    logger.info("Using One-Class SVM for dynamic analysis.")
+                    # nu is an upper bound on the fraction of training errors and a lower bound of the fraction of support vectors.
+                    # Should be in the interval (0, 1]. Common values are 0.01 to 0.1
+                    dynamic_model = OneClassSVM(
+                        nu=0.05, # Example value, might need tuning
+                        kernel="rbf",
+                        gamma='auto' # Or scale
+                    )
+                    # Fit on the dynamic features (no labels needed)
+                    dynamic_model.fit(X_dynamic_selected)
                 
-                # Select dynamic features (needs same feature names later for prediction)
-                dynamic_selected_features = list(X_dynamic.columns[:20])  # Simplified for test, convert to list for consistency
+                else:
+                    logger.error(f"Unsupported dynamic model type: {args.dynamic_model_type}")
+                    return False # Or raise an error
                 
                 # Prepare test data with consistent features
                 logger.info("Preparing test data...")
                 X_static_test_selected = X_static_test[static_selected_features]
+                # Ensure the dynamic test set uses the same features the dynamic model was trained on
                 X_dynamic_test_selected = X_dynamic[dynamic_selected_features]
                 
                 # Get a small subset for testing


### PR DESCRIPTION
Adds support for using one-class classifiers (Isolation Forest, One-Class SVM) for the dynamic analysis stage via the  argument.
This adaptation addresses the limitation of the CICAndMAl2020 dataset lacking benign dynamic samples.

Changes include:
- Modified  to parse the new argument and train the selected dynamic model type.
- Updated  to handle prediction outputs from one-class models (mapping +/-1 to probability-like scores).
- Updated  to document the new argument, explain the dataset limitation, and describe the one-class adaptation.
- Minor related changes in cicandmal2020_loader.py